### PR TITLE
Fix light theme palette

### DIFF
--- a/public/scripts/theme.js
+++ b/public/scripts/theme.js
@@ -44,14 +44,15 @@ function toggleLightDark() {
 }
 
 function updateIcon(theme) {
-  const sun = document.getElementById('icon-sun');
-  const moon = document.getElementById('icon-moon');
-
-  if (!sun || !moon) return;
-
   const isLight = theme.includes('light') || theme === 'light';
-  sun.style.opacity = isLight ? '1' : '0';
-  moon.style.opacity = isLight ? '0' : '1';
+
+  document.querySelectorAll('[id^="icon-sun-"]').forEach(el => {
+    el.style.opacity = isLight ? '1' : '0';
+  });
+
+  document.querySelectorAll('[id^="icon-moon-"]').forEach(el => {
+    el.style.opacity = isLight ? '0' : '1';
+  });
 }
 
 function initTheme() {

--- a/public/scripts/theme.js
+++ b/public/scripts/theme.js
@@ -60,19 +60,19 @@ function initTheme() {
   setTheme(active);
 }
 
-function toggleThemeMenu() {
-  const menu = document.getElementById('theme-menu');
+function toggleThemeMenu(id) {
+  const menu = document.getElementById(`theme-menu-${id}`);
   if (!menu) return;
   menu.classList.toggle('hidden');
 }
 
 // Auto-close dropdown on outside click
 document.addEventListener('click', (e) => {
-  const menu = document.getElementById('theme-menu');
-  if (!menu || menu.classList.contains('hidden')) return;
-  if (!menu.parentElement.contains(e.target)) {
-    menu.classList.add('hidden');
-  }
+  document.querySelectorAll('[id^="theme-menu-"]').forEach(menu => {
+    if (!menu.classList.contains('hidden') && !menu.parentElement.contains(e.target)) {
+      menu.classList.add('hidden');
+    }
+  });
 });
 
 // Watch for dropdown change

--- a/src/components/LightSwitch.astro
+++ b/src/components/LightSwitch.astro
@@ -1,8 +1,6 @@
 ---
 // LightSwitch.astro
----
----
-const id = Math.random().toString(36).slice(2,8);
+const id = Math.random().toString(36).slice(2, 8);
 ---
 <button
   id={`theme-toggle-btn-${id}`}

--- a/src/components/LightSwitch.astro
+++ b/src/components/LightSwitch.astro
@@ -1,15 +1,18 @@
 ---
 // LightSwitch.astro
 ---
+---
+const id = Math.random().toString(36).slice(2,8);
+---
 <button
-  id="theme-toggle-btn"
+  id={`theme-toggle-btn-${id}`}
   onclick="toggleLightDark()"
   class="relative w-10 h-10 p-2 rounded-full border border-[var(--color-border)] bg-[var(--color-surface)] text-[var(--color-text)]"
   aria-label="Toggle Light/Dark"
 >
   <!-- Sun icon (Light Mode) -->
   <svg
-    id="icon-sun"
+    id={`icon-sun-${id}`}
     class="absolute inset-0 w-6 h-6 m-auto transition-opacity duration-300 opacity-0"
     xmlns="http://www.w3.org/2000/svg"
     viewBox="0 0 24 24"
@@ -22,7 +25,7 @@
 
   <!-- Moon icon (Dark Mode) -->
   <svg
-    id="icon-moon"
+    id={`icon-moon-${id}`}
     class="absolute inset-0 w-6 h-6 m-auto transition-opacity duration-300 opacity-0"
     xmlns="http://www.w3.org/2000/svg"
     viewBox="0 0 24 24"

--- a/src/components/ThemePalette.astro
+++ b/src/components/ThemePalette.astro
@@ -1,9 +1,10 @@
 ---
 // ThemeSelector.astro
+const id = Math.random().toString(36).slice(2,8);
 ---
 <div class="relative inline-block">
   <button
-    onclick="toggleThemeMenu()"
+    onclick={`toggleThemeMenu('${id}')`}
     class="w-10 h-10 p-2 rounded-full border border-[var(--color-border)] bg-[var(--color-surface)] text-[var(--color-text)]"
     aria-label="Open theme menu"
   >
@@ -22,7 +23,7 @@
 
   <!-- Theme menu -->
   <ul
-    id="theme-menu"
+    id={`theme-menu-${id}`}
     class="hidden absolute right-0 mt-2 w-48 bg-[var(--color-surface)] border border-[var(--color-border)] text-[var(--color-text)] rounded shadow-md z-10"
   >
     {[

--- a/src/components/ThemeToggle.astro
+++ b/src/components/ThemeToggle.astro
@@ -48,14 +48,14 @@ const id = Math.random().toString(36).slice(2,8);
 
 <!-- Light/Dark.astro -->
 <button
-  id="theme-toggle-btn"
+  id={`theme-toggle-btn-${id}`}
   onclick="toggleLightDark()"
   class="relative w-10 h-10 p-2 rounded-full border border-[var(--color-border)] bg-[var(--color-surface)] text-[var(--color-text)]"
   aria-label="Toggle Light/Dark"
 >
   <!-- Sun icon (Light Mode) -->
   <svg
-    id="icon-sun"
+    id={`icon-sun-${id}`}
     class="absolute inset-0 w-6 h-6 m-auto transition-opacity duration-300 opacity-0"
     xmlns="http://www.w3.org/2000/svg"
     viewBox="0 0 24 24"
@@ -68,7 +68,7 @@ const id = Math.random().toString(36).slice(2,8);
 
   <!-- Moon icon (Dark Mode) -->
   <svg
-    id="icon-moon"
+    id={`icon-moon-${id}`}
     class="absolute inset-0 w-6 h-6 m-auto transition-opacity duration-300 opacity-0"
     xmlns="http://www.w3.org/2000/svg"
     viewBox="0 0 24 24"

--- a/src/components/ThemeToggle.astro
+++ b/src/components/ThemeToggle.astro
@@ -1,9 +1,10 @@
 ---
 // ThemeToggle.astro
+const id = Math.random().toString(36).slice(2,8);
 ---
 <div class="relative inline-block">
   <button
-    onclick="toggleThemeMenu()"
+    onclick={`toggleThemeMenu('${id}')`}
     class="w-10 h-10 p-2 rounded-full border border-[var(--color-border)] bg-[var(--color-surface)] text-[var(--color-text)]"
     aria-label="Open theme menu"
   >
@@ -22,7 +23,7 @@
 
   <!-- Theme menu -->
   <ul
-    id="theme-menu"
+    id={`theme-menu-${id}`}
     class="hidden absolute right-0 mt-2 w-48 bg-[var(--color-surface)] border border-[var(--color-border)] text-[var(--color-text)] rounded shadow-md z-10"
   >
     {[

--- a/src/styles/theme.css
+++ b/src/styles/theme.css
@@ -108,6 +108,10 @@
 }
 
 .theme-light {
+  --color-bg: #ffffff;
+  --color-surface: #f3f4f6;
+  --color-subtle: #3b82f6;
+  --color-hover: #1d4ed8;
   --color-primary: #2274a5;
   --color-secondary: #2274a5;
   --color-accent: #22d3ee;
@@ -122,6 +126,10 @@
 }
 
 .theme-dark {
+  --color-bg: #21252d;
+  --color-surface: #1a1e2a;
+  --color-subtle: #bfdbfe;
+  --color-hover: #60a5fa;
   --color-primary: #ec4899;
   --color-secondary: #2274a5;
   --color-accent: #22d3ee;


### PR DESCRIPTION
## Summary
- define missing color vars for the `light` and `dark` themes
- ensure each theme menu has a unique ID so multiple menus work on the same page

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684e05c293b4833098256ab5b614b1ab